### PR TITLE
Add PGUSER environment variable to nublado2.

### DIFF
--- a/services/nublado2/values-usdfdev.yaml
+++ b/services/nublado2/values-usdfdev.yaml
@@ -31,6 +31,7 @@ config:
 
   lab_environment:
     PGPASSFILE: "/opt/lsst/software/jupyterlab/butler-secret/postgres-credentials.txt"
+    PGUSER: "rubin"
     AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini"
     DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
     S3_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"

--- a/services/nublado2/values-usdfprod.yaml
+++ b/services/nublado2/values-usdfprod.yaml
@@ -31,6 +31,7 @@ config:
 
   lab_environment:
     PGPASSFILE: "/opt/lsst/software/jupyterlab/butler-secret/postgres-credentials.txt"
+    PGUSER: "rubin"
     AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini"
     DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
     S3_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"


### PR DESCRIPTION
This variable is necessary for the Butler Registry connections via SQLAlchemy and psycopg2 to use the provided PGPASSFILE credential, as the user's Unix id is always different from the database username.